### PR TITLE
Fix CentOS 7 OS check

### DIFF
--- a/Autosnort - CentOS/autosnort-CentOS-08-25-2014.sh
+++ b/Autosnort - CentOS/autosnort-CentOS-08-25-2014.sh
@@ -88,8 +88,10 @@ cp /usr/src/$snortver/etc/gen-msg.map /usr/local/snort/etc
 ########################################
 
 print_status "OS Version Check.."
-release=`cat /etc/redhat-release|awk '{print $3}'`
-if [[ $release == "6."* || $release == "7."* ]]; then
+
+# /etc/redhat-release differs between 6 and 7, so let's grab the whole thing.
+# Use Perl regex engine (for negative lookbehinds) to ensure we account for major and minor versions (e.g. 6.7 and 7.4.1046)
+if [[ `cat /etc/redhat-release | grep -P '(?<!\.)[67]\.[0-9]+(\.[0-9]+)?'` ]]; then
 	print_good "OS is CentOS. Good to go."
 else
     print_notification "This is not CentOS 6 or CentOS 7. Be aware this script has NOT been tested on other platforms (Including RHEL, Fedora and/or SuSE)."


### PR DESCRIPTION
When using awk in CentOS 7, the number is the 4th item instead of the 3rd. To remediate this instead use a regular expression to match on the whole string and ensure a period doesn't precede 6 or 7. However implementing the Perl regex engine with `grep -P` to use a negative lookbehind to make sure we don't match against 6 or 7 if it is preceded by a period.

Does match:
CentOS Linux release **6.6.8**
CentOS Linux release **7.0.1406**
CentOS Linux **6.4**

Doesn't match:
CentOS Linux release 5.7
CentOS Linux 5.6.8
