### PR TITLE
Correct print_notificiation => print_notification

### DIFF
--- a/Autosnort - Debian/autosnort-debian-11-02-2014.sh
+++ b/Autosnort - Debian/autosnort-debian-11-02-2014.sh
@@ -508,7 +508,7 @@ print_status "Checking for snort user and group.."
 
 getent passwd snort &>> $logfile
 if [ $? -eq 0 ]; then
-	print_notificiation "snort user exists. Verifying group exists.."
+	print_notification "snort user exists. Verifying group exists.."
 	id -g snort &>> $logfile
 	if [ $? -eq 0 ]; then
 		print_notification "snort group exists."

--- a/Autosnort - Kali/autosnort-kali-11-02-2014.sh
+++ b/Autosnort - Kali/autosnort-kali-11-02-2014.sh
@@ -451,7 +451,7 @@ print_status "Checking for snort user and group.."
 
 getent passwd snort &>> $logfile
 if [ $? -eq 0 ]; then
-	print_notificiation "snort user exists. Verifying group exists.."
+	print_notification "snort user exists. Verifying group exists.."
 	id -g snort &>> $logfile
 	if [ $? -eq 0 ]; then
 		print_notification "snort group exists."

--- a/Autosnort - Ubuntu/autosguil-ubuntu.sh
+++ b/Autosnort - Ubuntu/autosguil-ubuntu.sh
@@ -152,7 +152,7 @@ print_status "Checking for sguil user and group.."
 
 getent passwd sguil &>> $sguil_logfile
 if [ $? -eq 0 ]; then
-	print_notificiation "sguil user exists. Verifying group exists.."
+	print_notification "sguil user exists. Verifying group exists.."
 	id -g sguil &>> $sguil_logfile
 	if [ $? -eq 0 ]; then
 		print_notification "sguil group exists."

--- a/Autosnort - Ubuntu/autosnort-ubuntu-08-11-2015.sh
+++ b/Autosnort - Ubuntu/autosnort-ubuntu-08-11-2015.sh
@@ -454,7 +454,7 @@ print_status "Checking for snort user and group.."
 
 getent passwd snort &>> $logfile
 if [ $? -eq 0 ]; then
-	print_notificiation "snort user exists. Verifying group exists.."
+	print_notification "snort user exists. Verifying group exists.."
 	id -g snort &>> $logfile
 	if [ $? -eq 0 ]; then
 		print_notification "snort group exists."


### PR DESCRIPTION
Correct spelling and consequent runtime error:

```
[*] Checking for snort user and group..
autosnort-ubuntu-08-11-2015.sh: line 457: print_notificiation: command not found
[*] snort group exists.
```