### PR TITLE
Fixed unescaped parentheses within string

### DIFF
--- a/Autosnort - Ubuntu/AVATAR/autosnort-ubuntu-AVATAR.sh
+++ b/Autosnort - Ubuntu/AVATAR/autosnort-ubuntu-AVATAR.sh
@@ -423,7 +423,7 @@ else
 		if [ $? == 0 ]; then
 			pp_postprocessing
 		else
-			print_error "Rule download for $choice3 has failed. Trying text-only rule download for $choice4 (Final shot!)"
+			print_error "Rule download for $choice3 has failed. Trying text-only rule download for $choice4 \(Final shot!\)"
 			perl pulledpork.pl -S $choice4 -c /usr/src/pulledpork/etc/pulledpork.conf -W -T -vv &>> $logfile
 			if [ $? == 0 ]; then
 				pp_postprocessing


### PR DESCRIPTION
```
[*] Generating pulledpork.conf.
autosnort-ubuntu-AVATAR.sh: line 426: syntax error near unexpected token `('
autosnort-ubuntu-AVATAR.sh: line 426: `			print_error "Rule download for $choice3 has failed. Trying text-only rule download for $choice4 (Final shot!)"'
root@hostname:/tmp/Autosnort/Autosnort - Ubuntu/AVATAR# vi autosnort-ubuntu-AVATAR.sh
root@hostname:/tmp/Autosnort/Autosnort - Ubuntu/AVATAR# bash autosnort-ubuntu-AVATAR.sh
```

Escaped parentheses on line 426 to allow for successful completion of script.