### PR TITLE
Updated IPBlacklist URL and Version number

### DIFF
--- a/Autosnort-Ubuntu/AVATAR/autosnort-ubuntu-AVATAR.sh
+++ b/Autosnort-Ubuntu/AVATAR/autosnort-ubuntu-AVATAR.sh
@@ -449,7 +449,7 @@ fi
 echo "rule_url=https://www.snort.org/reg-rules/|snortrules-snapshot.tar.gz|$o_code" > pulledpork.tmp
 echo "rule_url=https://snort.org/downloads/community/|opensource.gz|Opensource" >> pulledpork.tmp
 echo "rule_url=https://snort.org/downloads/community/|community-rules.tar.gz|Community" >> pulledpork.tmp
-echo "rule_url=http://talosintel.com/feeds/ip-filter.blf|IPBLACKLIST|open" >> pulledpork.tmp
+echo "rule_url=http://talosintel.com/feeds/|ip-filter.blf|IPBLACKLIST|open" >> pulledpork.tmp
 echo "ignore=deleted.rules,experimental.rules,local.rules" >> pulledpork.tmp
 echo "temp_path=/tmp" >> pulledpork.tmp
 echo "rule_path=$snort_basedir/rules/snort.rules" >> pulledpork.tmp
@@ -465,7 +465,7 @@ echo "config_path=$snort_basedir/etc/snort.conf" >> pulledpork.tmp
 echo "black_list=$snort_basedir/rules/black_list.rules" >>pulledpork.tmp
 echo "IPRVersion=$snort_basedir/rules/iplists" >>pulledpork.tmp	
 echo "ips_policy=security" >> pulledpork.tmp
-echo "version=0.7.4" >> pulledpork.tmp
+echo "version=0.8.0" >> pulledpork.tmp
 cp pulledpork.tmp pulledpork.conf
 
 #Run pulledpork. If the first rule download fails, we try again, and so on until there are no other snort rule tarballs to attempt to download.


### PR DESCRIPTION
Added a pipe in the URL for the blacklist download because pulledpork.pl was parsing IPBLACKLIST as the file name to download instead of ip-filter. This was causing the script to fail because pulledpork.pl issues a croak command if the file fails to download and autosnort won't complete unless it gets a successful completion response from pulledpork.

Also updated the version number from 0.7.4 to 0.8.0 because the version number in the pulledpork repo was updated in Sep 2020 and pulledpork.pl was issuing a croak command when it saw that the version numbers in the .conf file didn't match the .pl file that was updated, again causing the autosnort script to fail.

[Side Note: I updated this in the github.com website file editor, and it added a newline terminator to the end of the file which is why that change is showing. I haven't been able to figure out how to keep it from doing that, but this wasn't a change I was trying to make.]